### PR TITLE
Add Qt HID wrapper for Stream Deck

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.10)
+project(QtStreamDeck VERSION 0.1.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(Qt5 5.15 REQUIRED COMPONENTS Core Gui Svg)
+find_package(hidapi REQUIRED)
+
+add_subdirectory(src)
+add_subdirectory(examples)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # QtStreamDeck
-a qt wrapper around the Elgato StreamDeck
+
+QtStreamDeck is a Qt 5.15 C++ wrapper around the Elgato Stream Deck HID
+protocol. It allows applications to send images to keys and receive button
+press events. Multiple Stream Decks can be used simultaneously and are
+identified by their serial numbers.
+
+## Building
+
+This project uses CMake. Qt 5.15 and `hidapi` are required.
+
+```bash
+mkdir build && cd build
+cmake ..
+make
+```
+
+The `examples` directory contains a small example showing how to use the
+library.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(example_simple simple_example.cpp)
+
+target_link_libraries(example_simple QtStreamDeck Qt5::Core Qt5::Gui Qt5::Svg)

--- a/examples/simple_example.cpp
+++ b/examples/simple_example.cpp
@@ -1,0 +1,34 @@
+#include <QCoreApplication>
+#include <QImage>
+#include "StreamDeckManager.h"
+#include "StreamDeckDevice.h"
+#include <iostream>
+
+int main(int argc, char **argv)
+{
+    QCoreApplication app(argc, argv);
+
+    auto serials = StreamDeckManager::availableSerialNumbers();
+    if (serials.isEmpty()) {
+        std::cerr << "No Stream Deck found" << std::endl;
+        return 0;
+    }
+
+    auto deck = StreamDeckManager::openDevice(serials.first());
+    if (!deck) {
+        std::cerr << "Failed to open device" << std::endl;
+        return 0;
+    }
+
+    QObject::connect(deck.get(), &StreamDeckDevice::buttonPressed, [](int key, bool pressed){
+        std::cout << "Key " << key << (pressed ? " down" : " up") << std::endl;
+    });
+
+    deck->start();
+
+    QImage img(72,72,QImage::Format_RGB888);
+    img.fill(Qt::blue);
+    deck->setImage(0, img);
+
+    return app.exec();
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,18 @@
+add_library(QtStreamDeck SHARED
+    StreamDeckDevice.cpp
+    StreamDeckManager.cpp
+)
+
+target_include_directories(QtStreamDeck PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_link_libraries(QtStreamDeck
+    Qt5::Core
+    Qt5::Gui
+    Qt5::Svg
+    hidapi::hidapi
+)
+
+set_target_properties(QtStreamDeck PROPERTIES
+    VERSION ${PROJECT_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR}
+)

--- a/src/StreamDeckDevice.cpp
+++ b/src/StreamDeckDevice.cpp
@@ -1,0 +1,99 @@
+#include "StreamDeckDevice.h"
+#include <QBuffer>
+#include <QImageReader>
+#include <QSvgRenderer>
+#include <QPainter>
+
+StreamDeckReadThread::StreamDeckReadThread(hid_device *dev, QObject *parent)
+    : QThread(parent), m_dev(dev)
+{
+}
+
+void StreamDeckReadThread::stop()
+{
+    m_running = false;
+}
+
+void StreamDeckReadThread::run()
+{
+    while (m_running) {
+        unsigned char buf[64];
+        int res = hid_read(m_dev, buf, sizeof(buf));
+        if (res > 0) {
+            int key = buf[1];
+            bool state = buf[2];
+            emit buttonEvent(key, state);
+        } else if (res < 0) {
+            break;
+        }
+    }
+}
+
+StreamDeckDevice::StreamDeckDevice(const QString &serial, hid_device *dev, QObject *parent)
+    : QObject(parent), m_serial(serial), m_device(dev)
+{
+}
+
+StreamDeckDevice::~StreamDeckDevice()
+{
+    stop();
+    if (m_device)
+        hid_close(m_device);
+}
+
+QString StreamDeckDevice::serialNumber() const
+{
+    return m_serial;
+}
+
+bool StreamDeckDevice::start()
+{
+    if (!m_device || m_thread)
+        return false;
+    m_thread = new StreamDeckReadThread(m_device);
+    connect(m_thread, &StreamDeckReadThread::buttonEvent, this, &StreamDeckDevice::buttonPressed);
+    m_thread->start();
+    return true;
+}
+
+void StreamDeckDevice::stop()
+{
+    if (!m_thread)
+        return;
+    m_thread->stop();
+    m_thread->wait();
+    delete m_thread;
+    m_thread = nullptr;
+}
+
+static QImage renderSvg(const QString &path, const QSize &size)
+{
+    QSvgRenderer renderer(path);
+    QImage image(size, QImage::Format_ARGB32_Premultiplied);
+    image.fill(Qt::transparent);
+    QPainter p(&image);
+    renderer.render(&p);
+    return image;
+}
+
+static QByteArray prepareImage(const QImage &img)
+{
+    QImage rgb = img.convertToFormat(QImage::Format_RGB888);
+    QByteArray data(reinterpret_cast<const char*>(rgb.constBits()), rgb.sizeInBytes());
+    return data;
+}
+
+void StreamDeckDevice::setImage(int keyIndex, const QImage &image)
+{
+    if (!m_device)
+        return;
+    QImage scaled = image.scaled(72, 72, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    QByteArray payload = prepareImage(scaled);
+
+    QByteArray packet;
+    packet.resize(1 + payload.size());
+    packet[0] = static_cast<char>(keyIndex);
+    std::copy(payload.begin(), payload.end(), packet.begin() + 1);
+
+    hid_write(m_device, reinterpret_cast<const unsigned char*>(packet.constData()), packet.size());
+}

--- a/src/StreamDeckDevice.h
+++ b/src/StreamDeckDevice.h
@@ -1,0 +1,49 @@
+#ifndef STREAMDECKDEVICE_H
+#define STREAMDECKDEVICE_H
+
+#include <QObject>
+#include <QImage>
+#include <QThread>
+#include <hidapi/hidapi.h>
+#include <atomic>
+
+class StreamDeckReadThread : public QThread
+{
+    Q_OBJECT
+public:
+    explicit StreamDeckReadThread(hid_device *dev, QObject *parent = nullptr);
+    void run() override;
+    void stop();
+
+signals:
+    void buttonEvent(int keyIndex, bool pressed);
+
+private:
+    hid_device *m_dev;
+    std::atomic<bool> m_running{true};
+};
+
+class StreamDeckDevice : public QObject
+{
+    Q_OBJECT
+public:
+    explicit StreamDeckDevice(const QString &serial, hid_device *dev, QObject *parent = nullptr);
+    ~StreamDeckDevice();
+
+    QString serialNumber() const;
+
+    bool start();
+    void stop();
+
+    void setImage(int keyIndex, const QImage &image);
+
+signals:
+    void buttonPressed(int keyIndex, bool pressed);
+
+private:
+    QString m_serial;
+    hid_device *m_device{nullptr};
+    StreamDeckReadThread *m_thread{nullptr};
+};
+
+#endif // STREAMDECKDEVICE_H

--- a/src/StreamDeckManager.cpp
+++ b/src/StreamDeckManager.cpp
@@ -1,0 +1,30 @@
+#include "StreamDeckManager.h"
+#include "StreamDeckDevice.h"
+#include <QString>
+#include <QList>
+
+QList<QString> StreamDeckManager::availableSerialNumbers()
+{
+    QList<QString> serials;
+    hid_device_info *info = hid_enumerate(0x0, 0x0);
+    hid_device_info *cur = info;
+    while (cur) {
+        QString manufacturer = QString::fromWCharArray(cur->manufacturer_string ? cur->manufacturer_string : L"");
+        QString product = QString::fromWCharArray(cur->product_string ? cur->product_string : L"");
+        if (manufacturer.contains("Elgato", Qt::CaseInsensitive) && product.contains("Stream Deck", Qt::CaseInsensitive)) {
+            if (cur->serial_number)
+                serials.append(QString::fromWCharArray(cur->serial_number));
+        }
+        cur = cur->next;
+    }
+    hid_free_enumeration(info);
+    return serials;
+}
+
+std::unique_ptr<StreamDeckDevice> StreamDeckManager::openDevice(const QString &serial, QObject *parent)
+{
+    hid_device *dev = hid_open(0x0fd9, 0x0060, serial.isEmpty() ? nullptr : reinterpret_cast<const wchar_t*>(serial.utf16()));
+    if (!dev)
+        return nullptr;
+    return std::make_unique<StreamDeckDevice>(serial, dev, parent);
+}

--- a/src/StreamDeckManager.h
+++ b/src/StreamDeckManager.h
@@ -1,0 +1,17 @@
+#ifndef STREAMDECKMANAGER_H
+#define STREAMDECKMANAGER_H
+
+#include <QObject>
+#include <memory>
+#include <hidapi/hidapi.h>
+
+class StreamDeckDevice;
+
+class StreamDeckManager
+{
+public:
+    static QList<QString> availableSerialNumbers();
+    static std::unique_ptr<StreamDeckDevice> openDevice(const QString &serial, QObject *parent = nullptr);
+};
+
+#endif // STREAMDECKMANAGER_H


### PR DESCRIPTION
## Summary
- add CMake build system and project skeleton
- implement `StreamDeckDevice` and `StreamDeckManager` classes
- provide simple example using the wrapper
- document build instructions in README

## Testing
- `cmake ..` *(fails: could not find Qt5)*
- `make` *(fails: no makefile generated)*

------
https://chatgpt.com/codex/tasks/task_e_685874c7781c8333a7c95aadf61bb569